### PR TITLE
Added `Workflow` output ports

### DIFF
--- a/swirl/compiler/default.py
+++ b/swirl/compiler/default.py
@@ -29,7 +29,6 @@ imports = """from __future__ import annotations
 import glob
 import logging
 import os
-import shutil
 import socket
 import subprocess
 import time

--- a/swirl/compiler/default.py
+++ b/swirl/compiler/default.py
@@ -287,6 +287,15 @@ class DefaultTarget(BaseCompiler):
     ):
         for port_name, data in dataset:
             self.current_location.data[data.name] = data
+    def _get_indentation(self):
+        return " " * 4 if self.parallel_step_counter > 0 else ""
+
+    def begin_dataset(
+        self,
+        dataset: MutableSequence[tuple[str, Data]],
+    ):
+        for port_name, data in dataset:
+            self.current_location.data[data.name] = data
             self.programs[self.current_location.name].write(
                 f"""
     _init_dataset("{port_name}", "{data.value}")"""

--- a/swirl/config/schemas/v1.0/config_schema.json
+++ b/swirl/config/schemas/v1.0/config_schema.json
@@ -37,6 +37,10 @@
           "type": "integer",
           "description": "The port on which to open the connection."
         },
+        "outdir": {
+          "type": "string",
+          "description": "Path to the output directory."
+        },
         "workdir": {
           "type": "string",
           "description": "Path to the working directory."
@@ -55,6 +59,15 @@
         "port"
       ],
       "additionalProperties": false
+    },
+    "port": {
+      "type": "object",
+      "properties": {
+        "resultPort": {
+          "type": "boolean",
+          "description": "This port is an output of the workflow"
+        }
+      }
     },
     "step": {
       "type": "object",
@@ -122,6 +135,15 @@
       "patternProperties": {
         "^[a-z][a-zA-Z0-9]*$": {
           "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ports": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-zA-Z0-9]*$": {
+          "$ref": "#/$defs/port"
         }
       },
       "additionalProperties": false

--- a/swirl/config/schemas/v1.0/config_schema.json
+++ b/swirl/config/schemas/v1.0/config_schema.json
@@ -60,15 +60,6 @@
       ],
       "additionalProperties": false
     },
-    "port": {
-      "type": "object",
-      "properties": {
-        "resultPort": {
-          "type": "boolean",
-          "description": "This port is an output of the workflow"
-        }
-      }
-    },
     "step": {
       "type": "object",
       "properties": {
@@ -135,15 +126,6 @@
       "patternProperties": {
         "^[a-z][a-zA-Z0-9]*$": {
           "$ref": "#/$defs/location"
-        }
-      },
-      "additionalProperties": false
-    },
-    "ports": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z][a-zA-Z0-9]*$": {
-          "$ref": "#/$defs/port"
         }
       },
       "additionalProperties": false

--- a/swirl/core/compiler.py
+++ b/swirl/core/compiler.py
@@ -131,6 +131,7 @@ class CompileVisitor(SWIRLVisitor, ABC):
                     port=settings["port"],
                     connection_type=settings.get("connectionType", None),
                     workdir=settings.get("workdir", None),
+                    outdir=settings.get("outdir", None)
                 )
             )
 
@@ -232,6 +233,8 @@ class CompileVisitor(SWIRLVisitor, ABC):
                 )
                 for arg in step_metadata["arguments"]
             ]
+        for loc in mapping:
+            self.workflow.map(self.workflow.steps[name], self.workflow.locations[loc])
         return self.compiler.exec(self.workflow.steps[name], flow, mapping)
 
     def visitRecv(self, ctx: SWIRLParser.RecvContext):

--- a/swirl/core/compiler.py
+++ b/swirl/core/compiler.py
@@ -258,7 +258,7 @@ class CompileVisitor(SWIRLVisitor, ABC):
         else:
             # search in the output steps
             for value in self.metadata["steps"].values():
-                if info := value["outputs"].get(port, None):
+                if "outputs" in value and (info := value["outputs"].get(port, None)):
                     data_type = self.metadata["dependencies"][info["dataName"]]["type"]
                     break
         if data_type is None:
@@ -306,9 +306,6 @@ class CompileVisitor(SWIRLVisitor, ABC):
 
     def visitWorkflow(self, ctx: SWIRLParser.WorkflowContext):
         self.compiler.begin_workflow(self.workflow)
-        for res_port, enable in self.metadata.get("ports", {}).items():
-            if enable["resultPort"]:
-                self.workflow.add_result_port(res_port)
         val = self.visitChildren(ctx)
         self.compiler.end_workflow()
         return val

--- a/swirl/core/compiler.py
+++ b/swirl/core/compiler.py
@@ -131,7 +131,7 @@ class CompileVisitor(SWIRLVisitor, ABC):
                     port=settings["port"],
                     connection_type=settings.get("connectionType", None),
                     workdir=settings.get("workdir", None),
-                    outdir=settings.get("outdir", None)
+                    outdir=settings.get("outdir", None),
                 )
             )
 
@@ -306,6 +306,9 @@ class CompileVisitor(SWIRLVisitor, ABC):
 
     def visitWorkflow(self, ctx: SWIRLParser.WorkflowContext):
         self.compiler.begin_workflow(self.workflow)
+        for res_port, enable in self.metadata.get("ports", {}).items():
+            if enable["resultPort"]:
+                self.workflow.add_result_port(res_port)
         val = self.visitChildren(ctx)
         self.compiler.end_workflow()
         return val

--- a/swirl/core/entity.py
+++ b/swirl/core/entity.py
@@ -125,12 +125,11 @@ class Step:
 
 
 class Workflow:
-    __slots__ = ("steps", "ports", "result_ports", "dependencies", "__location")
+    __slots__ = ("steps", "ports", "dependencies", "__location")
 
     def __init__(self):
         self.steps: MutableMapping[str, Step] = {}
         self.ports: MutableMapping[str, Port] = {}
-        self.result_ports: MutableSequence[str] = []
         self.dependencies: set[tuple[str, str]] = set()
         self.__location: Location = Location(name="l", display_name="local", data={})
 
@@ -143,9 +142,6 @@ class Workflow:
         if port.name not in self.ports:
             self.ports[port.name] = port
         self.dependencies.add((step.name, port.name))
-
-    def add_result_port(self, port_name: str):
-        self.result_ports.append(port_name) if port_name not in self.ports else None
 
     def add_step(self, step: Step) -> None:
         self.steps[step.name] = step
@@ -199,9 +195,6 @@ class Workflow:
             [self.steps[d[1]] for d in self.dependencies if d[0] == port.name],
             key=lambda step: step.name,
         )
-
-    def get_result_ports(self):
-        return self.result_ports
 
     def get_step_locations(self, step: Step) -> MutableSequence[Location]:
         return [self.__location]

--- a/swirl/core/entity.py
+++ b/swirl/core/entity.py
@@ -21,6 +21,7 @@ class Location:
         "data",
         "connection_type",
         "workdir",
+        "outdir",
         "hostname",
         "port",
     )
@@ -33,7 +34,8 @@ class Location:
         connection_type: str | None = None,
         hostname: str | None = None,
         port: str | None = None,
-        workdir: str = None,
+        workdir: str | None = None,
+        outdir: str | None = None,
     ):
         self.data: MutableMapping[str, Any] = data
         self.display_name: str = display_name
@@ -41,6 +43,7 @@ class Location:
         self.connection_type: str = connection_type
         self.hostname: str | None = hostname
         self.port: str | None = port
+        self.outdir: str = outdir
         self.workdir: str = workdir
 
     def get_command(self, cmd: str) -> str:
@@ -121,11 +124,12 @@ class Step:
 
 
 class Workflow:
-    __slots__ = ("steps", "ports", "dependencies", "__location")
+    __slots__ = ("steps", "ports", "result_ports", "dependencies", "__location")
 
     def __init__(self):
         self.steps: MutableMapping[str, Step] = {}
         self.ports: MutableMapping[str, Port] = {}
+        self.result_ports: MutableSequence[str, str] = []
         self.dependencies: set[tuple[str, str]] = set()
         self.__location: Location = Location(name="l", display_name="local", data={})
 
@@ -133,6 +137,9 @@ class Workflow:
         if port.name not in self.ports:
             self.ports[port.name] = port
         self.dependencies.add((port.name, step.name))
+
+    def add_result_port(self, port_name: str):
+        self.result_ports.append(port_name) if port_name not in self.ports else None
 
     def add_output_port(self, step: Step, port: Port):
         if port.name not in self.ports:

--- a/swirl/core/translator.py
+++ b/swirl/core/translator.py
@@ -21,11 +21,6 @@ def _add_location(location, locations):
         locations[location.name]["outdir"] = location.outdir
 
 
-def _add_port(ports, workflow):
-    for port in workflow.result_ports:
-        ports[port] = {"resultPort": True}
-
-
 def _add_step(step, steps, workflow, dependencies):
     steps[step.name] = {
         "displayName": step.display_name,
@@ -62,11 +57,8 @@ class AbstractTranslator:
         # Dictionaries to generate metadata file
         dependencies = {}
         locations = {}
-        ports = {}
         steps = {}
         version = "v1.0"
-
-        _add_port(ports, workflow)
         nof_locations = len(workflow.get_locations())
         for i, location in enumerate(workflow.get_locations()):
             trace_recvs = set()
@@ -151,7 +143,6 @@ class AbstractTranslator:
             {
                 "version": version,
                 "steps": steps,
-                "ports": ports,
                 "locations": locations,
                 "dependencies": dependencies,
             },

--- a/swirl/core/translator.py
+++ b/swirl/core/translator.py
@@ -25,6 +25,7 @@ def _add_port(ports, workflow):
     for port in workflow.result_ports:
         ports[port] = {"resultPort": True}
 
+
 def _add_step(step, steps, workflow, dependencies):
     steps[step.name] = {
         "displayName": step.display_name,

--- a/swirl/core/translator.py
+++ b/swirl/core/translator.py
@@ -17,7 +17,13 @@ def _add_location(location, locations):
         locations[location.name]["connectionType"] = location.connection_type
     if location.workdir:
         locations[location.name]["workdir"] = location.workdir
+    if location.outdir:
+        locations[location.name]["outdir"] = location.outdir
 
+
+def _add_port(ports, workflow):
+    for port in workflow.result_ports:
+        ports[port] = {"resultPort": True}
 
 def _add_step(step, steps, workflow, dependencies):
     steps[step.name] = {
@@ -55,9 +61,11 @@ class AbstractTranslator:
         # Dictionaries to generate metadata file
         dependencies = {}
         locations = {}
+        ports = {}
         steps = {}
         version = "v1.0"
 
+        _add_port(ports, workflow)
         nof_locations = len(workflow.get_locations())
         for i, location in enumerate(workflow.get_locations()):
             trace_recvs = set()
@@ -142,6 +150,7 @@ class AbstractTranslator:
             {
                 "version": version,
                 "steps": steps,
+                "ports": ports,
                 "locations": locations,
                 "dependencies": dependencies,
             },

--- a/swirl/translator/dax_translator.py
+++ b/swirl/translator/dax_translator.py
@@ -180,9 +180,8 @@ class DAXTranslator(AbstractTranslator):
 
         # Initial dataset
         replicas_config = _open_yml(self.replicas_path.as_posix())
-        # data_locations = {
-        #   logical_data_name : [ (location_name, physical_data_name) ]
-        # }
+
+        # logical_data_name : [ (location_name, physical_data_name) ]
         data_locations = {}
         for replica in replicas_config["replicas"]:
             for physical_path in replica["pfns"]:

--- a/swirl/translator/dax_translator.py
+++ b/swirl/translator/dax_translator.py
@@ -106,6 +106,8 @@ class DAXTranslator(AbstractTranslator):
                     swirl_output_steps.setdefault(swirl_step_name, []).append(
                         swirl_data_name
                     )
+                    if data["stageOut"]:
+                        workflow.add_result_port(swirl_data_name)
             swirl_step_args[swirl_step_name] = [arg for arg in replica["arguments"]]
 
         # Create the steps
@@ -167,6 +169,11 @@ class DAXTranslator(AbstractTranslator):
                 for directory in site["directories"]
                 if directory["type"] == "sharedScratch"
             ]
+            outdirs = [
+                directory["path"]
+                for directory in site["directories"]
+                if directory["type"] == "localStorage"
+            ]
             location = Location(
                 name=location_binding_dax_swirl[site["name"]],
                 display_name=site["name"],
@@ -174,6 +181,7 @@ class DAXTranslator(AbstractTranslator):
                 hostname=site.get("hostname", "127.0.0.1"),
                 port=site.get("port", 35050),
                 workdir=next(iter(workdirs)) if workdirs else None,
+                outdir=next(iter(outdirs)) if outdirs else None,
                 connection_type=site.get("connectionType", "ssh"),
             )
             workflow.add_location(location)

--- a/swirl/translator/dax_translator.py
+++ b/swirl/translator/dax_translator.py
@@ -84,7 +84,8 @@ class DAXTranslator(AbstractTranslator):
         # dax_step_name : dax_step_id
         dax_step_name_id: MutableMapping[str, MutableSequence[str]] = {}
 
-        data_stage_out = []
+        # swirl_step_name : [ collector_step_name ]
+        binding_collector_step = {}
 
         # Visit workflow yaml
         workflow_config = _open_yml(self.workflow_path.as_posix())
@@ -109,7 +110,26 @@ class DAXTranslator(AbstractTranslator):
                         swirl_data_name
                     )
                     if data["stageOut"]:
-                        data_stage_out.append(swirl_data_name)
+                        # Generate a unique id for the collector step based on the DAX id of the previous step
+                        collect_id = "COLLECT-" + replica["id"]
+                        dax_step_name_id.setdefault(
+                            f"{replica['name']}-{swirl_data_name}-collector", []
+                        ).append(collect_id)
+                        swirl_collect_step_name = f"s{len(step_binding_dax_swirl)}"
+                        step_binding_dax_swirl[collect_id] = swirl_collect_step_name
+                        # Add option for the copy command
+                        swirl_step_args[swirl_collect_step_name] = [
+                            "-r",
+                            swirl_data_name,
+                        ]
+                        # Add output port of previous step as input of the collector step
+                        swirl_input_steps.setdefault(
+                            swirl_collect_step_name, []
+                        ).append(swirl_data_name)
+                        # Bind the collector step in the same location of previous step
+                        binding_collector_step.setdefault(swirl_step_name, set()).add(
+                            swirl_collect_step_name
+                        )
             swirl_step_args[swirl_step_name] = [arg for arg in replica["arguments"]]
 
         # Create the steps
@@ -119,7 +139,10 @@ class DAXTranslator(AbstractTranslator):
                 for dax_name, dax_ids in dax_step_name_id.items()
                 if dax_id in dax_ids
             )
-            workflow.add_step(Step(swirl_step_name, display_name))
+            step = Step(swirl_step_name, display_name)
+            workflow.add_step(step)
+            if dax_id.startswith("COLLECT-"):
+                step.command = "cp"
 
         # Add step output ports
         swirl_data_ports = {}
@@ -130,8 +153,6 @@ class DAXTranslator(AbstractTranslator):
                     f"p{len(swirl_data_ports)}",
                     {data_name},
                 )
-                if data_name in data_stage_out:
-                    workflow.add_result_port(swirl_data_ports[data_name].name)
                 workflow.add_output_port(
                     workflow.steps[step_name], swirl_data_ports[data_name]
                 )
@@ -228,7 +249,18 @@ class DAXTranslator(AbstractTranslator):
                 location_name = location_binding_dax_swirl[binding["name"]]
                 for dax_step_id in dax_step_name_id[transformation["name"]]:
                     step_name = step_binding_dax_swirl[dax_step_id]
-                    step = workflow.steps[step_name]
-                    step.command = binding["pfn"]
-                    workflow.map(step, workflow.locations[location_name])
+                    workflow.steps[step_name].command = binding["pfn"]
+                    workflow.map(
+                        workflow.steps[step_name], workflow.locations[location_name]
+                    )
+                    # Map the collector step and add last argument for the copy command
+                    for c in binding_collector_step.get(
+                        workflow.steps[step_name].name, []
+                    ):
+                        workflow.map(
+                            workflow.steps[c], workflow.locations[location_name]
+                        )
+                        workflow.steps[c].arguments.append(
+                            workflow.locations[location_name].outdir
+                        )
         return workflow


### PR DESCRIPTION
This commit adds output ports of the entire workflow. When a DAX workflow is translated, a new step is added for each workflow output port. These steps are at the end of a trace and they manage the copy data from `workdir` to `outdir` in a location.

Moreover, this commit adds the `outdir` attribute in the `Location` class. The data of the workflow output ports are copied in the `outdir` path of the related location.  The `workdir` attribute of the `Location` class instead is used as scratch directory.